### PR TITLE
Add local HTTPS certificate management and proxy scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,6 @@ report.[0-9]_.[0-9]_.[0-9]_.[0-9]_.json
 
 # Finder (MacOS) folder config
 .DS_Store
+
+# local certificates
+certs/

--- a/README.md
+++ b/README.md
@@ -1,3 +1,39 @@
 This is a monorepo that is designed for running a few apps locally.
 
-This project relies on `localcan` to manage local https:// domains and certificates, and mapping those to the various apps in the monorepo.
+Use the provided scripts to generate and clean up local HTTPS domains and certificates that map to the apps in this monorepo.
+
+## Setup
+
+1. Generate certificates and `/etc/hosts` entries (defaults: `primary.local`, `api.primary.local`, `satellite.local`):
+
+```sh
+npm run certs:setup
+```
+
+   Custom domains can be supplied as `domain:port` pairs:
+
+```sh
+npm run certs:setup -- example.test:7000 api.example.test:7001 static.example.test:7002
+```
+
+2. Start the HTTPS proxy (requires port 443):
+
+```sh
+sudo npm run proxy
+```
+
+3. In a separate terminal, start the apps:
+
+```sh
+npm run dev
+```
+
+Visit your configured domains in a browser over HTTPS.
+
+## Cleanup
+
+Remove the generated certificates and host entries:
+
+```sh
+npm run certs:cleanup
+```

--- a/README.md
+++ b/README.md
@@ -7,33 +7,59 @@ Use the provided scripts to generate and clean up local HTTPS domains and certif
 1. Generate certificates and `/etc/hosts` entries (defaults: `primary.local`, `api.primary.local`, `satellite.local`):
 
 ```sh
-npm run certs:setup
+bun run certs:setup
 ```
 
    Custom domains can be supplied as `domain:port` pairs:
 
 ```sh
-npm run certs:setup -- example.test:7000 api.example.test:7001 static.example.test:7002
+bun run certs:setup -- example.test:7000 api.example.test:7001 static.example.test:7002
 ```
 
-2. Start the HTTPS proxy (requires port 443):
+2. Start the apps (in separate terminals):
 
 ```sh
-sudo npm run proxy
+bun run dev
 ```
 
-3. In a separate terminal, start the apps:
+3. Launch Nginx (Docker) to terminate TLS and proxy to the apps:
 
 ```sh
-npm run dev
+bun run nginx:up
 ```
 
-Visit your configured domains in a browser over HTTPS.
+Visit your configured domains in a browser over HTTPS:
+- https://primary.local
+- https://api.primary.local
+- https://satellite.local
+
+To inspect or reload Nginx:
+
+```sh
+bun run nginx:logs
+docker compose exec nginx nginx -s reload
+```
 
 ## Cleanup
 
 Remove the generated certificates and host entries:
 
 ```sh
-npm run certs:cleanup
+bun run certs:cleanup
+```
+
+---
+
+### Learnings
+
+```console
+user@~: $ curl -w "@-" -o /dev/null -s http://localhost:6660 <<<$'connect:%{time_connect} start:%{time_starttransfer} total:%{time_total}\n'
+
+start:%{time_starttransfer} total:%{time_total}\n'
+connect:0.000261 start:0.000715 total:0.000773
+
+user@~: $ curl -w "@-" -o /dev/null -s https://primary.local <<<$'ssl:%{time_appconnect} start:%{time_starttransfer} total:%{time_total}\n'
+
+start:%{time_starttransfer} total:%{time_total}\n'
+ssl:0.000000 start:0.000000 total:5.021145
 ```

--- a/bun.lock
+++ b/bun.lock
@@ -5,6 +5,7 @@
       "name": "cookie-playground",
       "dependencies": {
         "hono": "^4.8.5",
+        "http-proxy": "^1.18.1",
       },
       "devDependencies": {
         "@types/bun": "latest",
@@ -36,9 +37,17 @@
 
     "csstype": ["csstype@3.1.3", "", {}, "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw=="],
 
+    "eventemitter3": ["eventemitter3@4.0.7", "", {}, "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw=="],
+
+    "follow-redirects": ["follow-redirects@1.15.11", "", {}, "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ=="],
+
     "hono": ["hono@4.8.5", "", {}, "sha512-Up2cQbtNz1s111qpnnECdTGqSIUIhZJMLikdKkshebQSEBcoUKq6XJayLGqSZWidiH0zfHRCJqFu062Mz5UuRA=="],
 
+    "http-proxy": ["http-proxy@1.18.1", "", { "dependencies": { "eventemitter3": "^4.0.0", "follow-redirects": "^1.0.0", "requires-port": "^1.0.0" } }, "sha512-7mz/721AbnJwIVbnaSv1Cz3Am0ZLT/UBwkC92VlxhXv/k/BBQfM2fXElQNC27BVGr0uwUpplYPQM9LnaBMR5NQ=="],
+
     "primary": ["primary@workspace:apps/6660-primary"],
+
+    "requires-port": ["requires-port@1.0.0", "", {}, "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ=="],
 
     "satellite": ["satellite@workspace:apps/6662-satellite"],
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,13 @@
+services:
+  nginx:
+    build:
+      context: .
+      dockerfile: proxy/Dockerfile
+    container_name: cookie-playground-nginx
+    ports:
+      - "80:80"
+      - "443:443"
+    extra_hosts:
+      # Allow container to reach host network on macOS/Windows Docker Desktop
+      - "host.docker.internal:host-gateway"
+    restart: unless-stopped

--- a/package.json
+++ b/package.json
@@ -14,10 +14,11 @@
     "dev": "bun --watch run --filter '*' --elide-lines=0 dev",
     "certs:setup": "node scripts/certs.js setup",
     "certs:cleanup": "node scripts/certs.js cleanup",
-    "proxy": "node scripts/proxy.js"
+    "nginx:up": "docker compose up -d nginx",
+    "nginx:down": "docker compose down",
+    "nginx:logs": "docker compose logs -f nginx"
   },
   "dependencies": {
-    "hono": "^4.8.5",
-    "http-proxy": "^1.18.1"
+    "hono": "^4.8.5"
   }
 }

--- a/package.json
+++ b/package.json
@@ -11,9 +11,13 @@
     "apps/*"
   ],
   "scripts": {
-    "dev": "bun --watch run --filter '*' --elide-lines=0 dev"
+    "dev": "bun --watch run --filter '*' --elide-lines=0 dev",
+    "certs:setup": "node scripts/certs.js setup",
+    "certs:cleanup": "node scripts/certs.js cleanup",
+    "proxy": "node scripts/proxy.js"
   },
   "dependencies": {
-    "hono": "^4.8.5"
+    "hono": "^4.8.5",
+    "http-proxy": "^1.18.1"
   }
 }

--- a/proxy/Dockerfile
+++ b/proxy/Dockerfile
@@ -1,0 +1,26 @@
+FROM nginx:1.27-alpine
+
+# Copy Nginx config from repo root
+COPY proxy/nginx.conf /etc/nginx/nginx.conf
+
+# Bake certs into the image and set secure permissions
+RUN set -eux; \
+    mkdir -p /etc/nginx/certs
+
+# Copy certificates directory (works even if empty) from repo root
+COPY certs/ /etc/nginx/certs/
+
+# Ensure nginx worker can read private keys (group-readable), but not world-readable
+RUN set -eux; \
+    chown -R root:nginx /etc/nginx/certs; \
+    chmod 644 /etc/nginx/certs/*.crt || true; \
+    chmod 640 /etc/nginx/certs/*.key || true; \
+    chmod 644 /etc/nginx/nginx.conf
+
+# Copy custom entrypoint shim and ensure it is executable from repo root
+COPY proxy/docker-entrypoint0.sh /docker-entrypoint0.sh
+RUN chmod +x /docker-entrypoint0.sh
+
+# ENTRYPOINT ["/docker-entrypoint0.sh"]
+
+# CMD ["nginx", "-g", "daemon off;"]

--- a/proxy/docker-entrypoint0.sh
+++ b/proxy/docker-entrypoint0.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+
+# Ensure host.docker.internal resolves on platforms where it doesn't by default
+HOST_DOMAIN="host.docker.internal"
+
+# If we can't reach the host domain, try to add a mapping to the default gateway
+if ! ping -c 1 "$HOST_DOMAIN" >/dev/null 2>&1; then
+  HOST_IP=$(ip route 2>/dev/null | awk 'NR==1 {print $3}')
+  # Fallback if `ip` isn't available
+  [ -z "$HOST_IP" ] && HOST_IP=$(route -n 2>/dev/null | awk '/^0.0.0.0/ {print $2; exit}')
+  if [ -n "$HOST_IP" ]; then
+    printf '%s\t%s\n' "$HOST_IP" "$HOST_DOMAIN" >> /etc/hosts
+  fi
+fi
+
+exec /docker-entrypoint.sh "$@"

--- a/proxy/nginx.conf
+++ b/proxy/nginx.conf
@@ -1,0 +1,103 @@
+# worker process can open by default 512 connections.
+worker_processes 4;
+
+events {}
+
+http {
+  # Improve connection handling
+  sendfile on;
+  tcp_nopush on;
+  tcp_nodelay on;
+  keepalive_timeout 65;
+  keepalive_requests 1000;
+
+
+  # Redirect all HTTP to HTTPS for our dev hosts
+  server {
+    listen 80;
+    server_name primary.local api.primary.local satellite.local;
+    return 301 https://$host$request_uri;
+  }
+
+  # primary.local -> Bun app on host port 6660
+  server {
+    listen 443 ssl http2;
+    server_name primary.local;
+
+    # Certificates mounted into the container at /etc/nginx/certs
+    ssl_certificate     /etc/nginx/certs/primary.local.crt;
+    ssl_certificate_key /etc/nginx/certs/primary.local.key;
+    ssl_protocols       TLSv1.2 TLSv1.3;
+
+    location / {
+      proxy_pass http://host.docker.internal:6660;
+      proxy_set_header Host $host;
+      proxy_set_header X-Real-IP $remote_addr;
+      proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+      proxy_set_header X-Forwarded-Proto $scheme;
+      proxy_http_version 1.1;
+
+
+      # Remove unconditional websocket upgrade — it disables keep-alive
+      # proxy_set_header Upgrade $http_upgrade;
+      # proxy_set_header Connection "upgrade";
+
+      # Enable upstream keep-alive
+      proxy_set_header Connection "";
+    }
+  }
+
+  # api.primary.local -> Bun app on host port 6661
+  server {
+    listen 443 ssl http2;
+    server_name api.primary.local;
+
+    ssl_certificate     /etc/nginx/certs/api.primary.local.crt;
+    ssl_certificate_key /etc/nginx/certs/api.primary.local.key;
+    ssl_protocols       TLSv1.2 TLSv1.3;
+
+    location / {
+      proxy_pass http://host.docker.internal:6661;
+      proxy_set_header Host $host;
+      proxy_set_header X-Real-IP $remote_addr;
+      proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+      proxy_set_header X-Forwarded-Proto $scheme;
+      proxy_http_version 1.1;
+
+
+      # Remove unconditional websocket upgrade — it disables keep-alive
+      # proxy_set_header Upgrade $http_upgrade;
+      # proxy_set_header Connection "upgrade";
+
+      # Enable upstream keep-alive
+      proxy_set_header Connection "";
+    }
+  }
+
+  # satellite.local -> Bun app on host port 6662
+  server {
+    listen 443 ssl http2;
+    server_name satellite.local;
+
+    ssl_certificate     /etc/nginx/certs/satellite.local.crt;
+    ssl_certificate_key /etc/nginx/certs/satellite.local.key;
+    ssl_protocols       TLSv1.2 TLSv1.3;
+
+    location / {
+      proxy_pass http://host.docker.internal:6662;
+      proxy_set_header Host $host;
+      proxy_set_header X-Real-IP $remote_addr;
+      proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+      proxy_set_header X-Forwarded-Proto $scheme;
+      proxy_http_version 1.1;
+
+
+      # Remove unconditional websocket upgrade — it disables keep-alive
+      # proxy_set_header Upgrade $http_upgrade;
+      # proxy_set_header Connection "upgrade";
+
+      # Enable upstream keep-alive
+      proxy_set_header Connection "";
+    }
+  }
+}

--- a/scripts/certs.js
+++ b/scripts/certs.js
@@ -1,0 +1,122 @@
+#!/usr/bin/env node
+
+const { execSync } = require('child_process');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const action = process.argv[2];
+const args = process.argv.slice(3);
+const defaultDomains = ['primary.local:6660', 'api.primary.local:6661', 'satellite.local:6662'];
+const mappings = (args.length ? args : defaultDomains).map((str) => {
+  const [host, port] = str.split(':');
+  return { host, port: Number(port) };
+});
+const domains = mappings.map((m) => m.host);
+
+const certDir = path.join(process.cwd(), 'certs');
+const hostFile = '/etc/hosts';
+const rootKey = path.join(certDir, 'localCA.key');
+const rootCert = path.join(certDir, 'localCA.pem');
+
+function run(cmd) {
+  execSync(cmd, { stdio: 'inherit' });
+}
+
+function ensureDir(dir) {
+  if (!fs.existsSync(dir)) {
+    fs.mkdirSync(dir, { recursive: true });
+  }
+}
+
+if (!['setup', 'cleanup'].includes(action)) {
+  console.log('Usage: node scripts/certs.js <setup|cleanup> [domain:port ...]');
+  process.exit(1);
+}
+
+if (action === 'setup') {
+  ensureDir(certDir);
+  if (!fs.existsSync(rootKey) || !fs.existsSync(rootCert)) {
+    run(`openssl genrsa -out ${rootKey} 2048`);
+    run(
+      `openssl req -x509 -new -nodes -key ${rootKey} -sha256 -days 825 -out ${rootCert} -subj "/CN=LocalDevCA"`
+    );
+    try {
+      if (process.platform === 'linux') {
+        run(`sudo cp ${rootCert} /usr/local/share/ca-certificates/localdev-ca.crt`);
+        run('sudo update-ca-certificates');
+      } else if (process.platform === 'darwin') {
+        run(
+          `sudo security add-trusted-cert -d -r trustRoot -k /Library/Keychains/System.keychain ${rootCert}`
+        );
+      }
+    } catch (err) {
+      console.error('Warning: failed to trust root certificate:', err.message);
+    }
+  }
+
+  domains.forEach((domain) => {
+    const key = path.join(certDir, `${domain}.key`);
+    const csr = path.join(certDir, `${domain}.csr`);
+    const cert = path.join(certDir, `${domain}.crt`);
+    const ext = path.join(certDir, `${domain}.ext`);
+
+    run(`openssl genrsa -out ${key} 2048`);
+    run(`openssl req -new -key ${key} -out ${csr} -subj "/CN=${domain}"`);
+    fs.writeFileSync(ext, `subjectAltName=DNS:${domain}${os.EOL}`);
+    run(
+      `openssl x509 -req -in ${csr} -CA ${rootCert} -CAkey ${rootKey} -CAcreateserial -out ${cert} -days 825 -sha256 -extfile ${ext}`
+    );
+    fs.unlinkSync(csr);
+    fs.unlinkSync(ext);
+
+    const hosts = fs.readFileSync(hostFile, 'utf8');
+    if (!hosts.includes(domain)) {
+      run(`echo "127.0.0.1 ${domain}" | sudo tee -a ${hostFile}`);
+    }
+  });
+
+  console.log('Certificates generated in certs/.');
+  console.log('Remember to run `npm run proxy` to start the HTTPS router.');
+}
+
+if (action === 'cleanup') {
+  domains.forEach((domain) => {
+    try {
+      fs.unlinkSync(path.join(certDir, `${domain}.key`));
+    } catch {}
+    try {
+      fs.unlinkSync(path.join(certDir, `${domain}.crt`));
+    } catch {}
+  });
+  ['localCA.srl', 'localCA.key', 'localCA.pem'].forEach((f) => {
+    try {
+      fs.unlinkSync(path.join(certDir, f));
+    } catch {}
+  });
+  try {
+    fs.rmdirSync(certDir);
+  } catch {}
+
+  let hostsContent = fs.readFileSync(hostFile, 'utf8');
+  domains.forEach((domain) => {
+    const regex = new RegExp(`^.*\\b${domain}\\b.*$`, 'gm');
+    hostsContent = hostsContent.replace(regex, '');
+  });
+  fs.writeFileSync(hostFile, hostsContent.trim() + os.EOL);
+
+  try {
+    if (process.platform === 'linux') {
+      run('sudo rm -f /usr/local/share/ca-certificates/localdev-ca.crt');
+      run('sudo update-ca-certificates');
+    } else if (process.platform === 'darwin') {
+      run(
+        'sudo security delete-certificate -c LocalDevCA /Library/Keychains/System.keychain'
+      );
+    }
+  } catch (err) {
+    console.error('Warning: failed to remove trusted root certificate:', err.message);
+  }
+
+  console.log('Certificates and hosts entries cleaned up.');
+}

--- a/scripts/proxy.js
+++ b/scripts/proxy.js
@@ -1,0 +1,60 @@
+#!/usr/bin/env node
+
+const https = require('https');
+const httpProxy = require('http-proxy');
+const tls = require('tls');
+const fs = require('fs');
+const path = require('path');
+
+const args = process.argv.slice(2);
+const defaultMappings = ['primary.local:6660', 'api.primary.local:6661', 'satellite.local:6662'];
+const mappings = (args.length ? args : defaultMappings).map((str) => {
+  const [host, port] = str.split(':');
+  return { host, port: Number(port) };
+});
+
+const certDir = path.join(process.cwd(), 'certs');
+const proxy = httpProxy.createProxyServer({});
+
+const sniContexts = {};
+mappings.forEach((m) => {
+  const key = fs.readFileSync(path.join(certDir, `${m.host}.key`));
+  const cert = fs.readFileSync(path.join(certDir, `${m.host}.crt`));
+  sniContexts[m.host] = tls.createSecureContext({ key, cert });
+});
+
+const server = https.createServer(
+  {
+    key: fs.readFileSync(path.join(certDir, `${mappings[0].host}.key`)),
+    cert: fs.readFileSync(path.join(certDir, `${mappings[0].host}.crt`)),
+    SNICallback: (servername, cb) => {
+      const ctx = sniContexts[servername];
+      if (ctx) {
+        cb(null, ctx);
+      } else {
+        cb(new Error('No certificate available for ' + servername));
+      }
+    },
+  },
+  (req, res) => {
+    const host = req.headers.host && req.headers.host.split(':')[0];
+    const route = mappings.find((m) => m.host === host);
+    if (!route) {
+      res.writeHead(502);
+      res.end('No route for host');
+      return;
+    }
+    proxy.web(req, res, { target: `http://127.0.0.1:${route.port}` });
+  }
+);
+
+server.on('connect', (req, socket) => {
+  socket.end();
+});
+
+server.listen(443, () => {
+  console.log('HTTPS proxy running:');
+  mappings.forEach((m) => {
+    console.log(`  https://${m.host} -> http://localhost:${m.port}`);
+  });
+});


### PR DESCRIPTION
## Summary
- add certs.js to generate local CA, domain certs, and host entries for three configurable domains
- add proxy.js HTTPS reverse proxy to route configured domains to app ports
- document setup and cleanup workflow and expose npm scripts

## Testing
- `npm run certs:setup`
- `npm run proxy` *(terminated manually)*
- `npm run certs:cleanup`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_6895e7690924832b945b0612cec5bb8f